### PR TITLE
[ci] Update .travis.yml: more versions, race, gofmt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
 language: go
-before_script:
-  - go vet ./...
+sudo: false
+
+matrix:
+  include:
+    - go: 1.4
+    - go: 1.5
+    - go: 1.6
+    - go: tip
+
+install:
+  - go get golang.org/x/tools/cmd/vet
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go tool vet .
+  - go test -v -race ./...


### PR DESCRIPTION
This is similar to the Travis config I use over on [gorilla/csrf](https://github.com/gorilla/csrf/blob/master/.travis.yml):

- Runs gofmt
- Runs go vet (no change)
- Runs the race detector during tests (although we need tests)

I've also set this up to run against older versions of Go. Ideally, we should run against Go 1.2 on up (since Debian 7 has Go 1.2), but I'm leaving that out for now until I can actually test it. A quick skim doesn't show anything that wouldn't be backwards compat.