### PR TITLE
[ci] Exclude vendored deps from Go tools.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - go get golang.org/x/tools/cmd/vet
 
 script:
-  - go get -t -v ./...
+  - go get -t -v $(go list ./... | grep -v '/vendor/')
   - diff -u <(echo -n) <(gofmt -d .)
-  - go tool vet .
-  - go test -v -race ./...
+  - go vet $(go list ./... | grep -v '/vendor/')
+  - go test -v -race $(go list ./... | grep -v '/vendor/')


### PR DESCRIPTION
Fixes the failing tests in #10 due to `go vet` attempting to run on the vendored deps.